### PR TITLE
fix(api): expose effective session settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,9 +363,10 @@ without scanning a QR — by a different route. That would be a wapi extension, 
 an open decision rather than an oversight.
 
 Current extensions: `POST /api/messages/react` (they emit `messages.reaction` as a webhook but
-document no way to send one), the three `/api/sandbox/*` controls, and `webhook_hmac`, which is
-dashboard-only. `/health` reports the cloned count and the extension count separately, so "29
-routes" stays a true claim about fidelity.
+document no way to send one), `GET /api/whatsapp-sessions/{id}/settings` (effective persisted
+controls omitted by the cloned detail shape), the three `/api/sandbox/*` controls, and
+`webhook_hmac`, which is dashboard-only. `/health` reports the cloned count and the extension
+count separately, so the cloned-route claim stays true.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ would not be.
 That claim is a test suite, not an aspiration: response schemas are checked against the
 provider's own documented examples, and again against live responses.
 
+WAPI-specific capabilities remain separate from that cloned surface. In particular,
+`GET /api/whatsapp-sessions/{id}/settings` exposes effective persisted controls that the cloned
+session-detail response omits, without returning the session credential or webhook secret.
+
 ## Clients
 
 Zero runtime dependencies either side. Types are generated from the OpenAPI document so they

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -7,6 +7,7 @@ import {
   generateWebhookSecret,
   hashToken,
   sessionDetailToWire,
+  sessionSettingsToWire,
   sessionToWire,
   validateProxy,
   validationFailure,
@@ -83,6 +84,13 @@ export function sessionRoutes(db: Db) {
     const row = await findOwned(db, c.get("auth").accountId, c.req.param("whatsappSession"));
     if (!row) return c.json(fail("The specified session was not found."), 404);
     return c.json(ok(sessionDetailToWire(row)));
+  });
+
+  /** GET /api/whatsapp-sessions/{id}/settings — wapi extension for effective settings. */
+  app.get("/whatsapp-sessions/:whatsappSession/settings", async (c) => {
+    const row = await findOwned(db, c.get("auth").accountId, c.req.param("whatsappSession"));
+    if (!row) return c.json(fail("The specified session was not found."), 404);
+    return c.json(ok(sessionSettingsToWire(row)));
   });
 
   /** PUT /api/whatsapp-sessions/{id} — update. This is where proxy_url is set. */
@@ -198,4 +206,3 @@ async function findOwned(db: Db, accountId: number, idParam: string) {
     .limit(1);
   return row ?? null;
 }
-

--- a/compat/sandbox.test.ts
+++ b/compat/sandbox.test.ts
@@ -111,6 +111,21 @@ d("credentials", () => {
   });
 });
 
+d("wapi session settings extension", () => {
+  test("reports the effective safety-critical settings", async () => {
+    const response = await json(
+      await api(`/api/whatsapp-sessions/${sessionId}/settings`, {}, PAT),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body["success"]).toBe(true);
+    expect(response.body["data"]).toMatchObject({
+      ignore_groups: false,
+      read_incoming_messages: false,
+    });
+  });
+});
+
 d("the six success envelopes", () => {
   test("GET /api/status is a bare object with no success wrapper", async () => {
     const r = await json(await api("/api/status"));

--- a/packages/contracts/src/extensions.ts
+++ b/packages/contracts/src/extensions.ts
@@ -72,6 +72,12 @@ export const postApiSandboxScanBody = z.object({});
 
 export const EXTENSION_ROUTES = [
   {
+    method: "GET",
+    operationId: "getApiWhatsappSessionsWhatsappSessionSettings",
+    path: "/api/whatsapp-sessions/{whatsappSession}/settings",
+    pathParams: ["whatsappSession"] as string[],
+  },
+  {
     body: postApiMessagesReactBody,
     method: "POST",
     operationId: "postApiMessagesReact",

--- a/packages/contracts/src/openapi.ts
+++ b/packages/contracts/src/openapi.ts
@@ -35,6 +35,7 @@ const SUMMARIES: Record<string, string> = {
   getApiWhatsappSessions: "List every WhatsApp session on the account",
   postApiWhatsappSessions: "Create a WhatsApp session and issue its API key",
   getApiWhatsappSessionsWhatsappSession: "Fetch one session, including its API key and webhook secret",
+  getApiWhatsappSessionsWhatsappSessionSettings: "Fetch a session's effective persisted settings",
   putApiWhatsappSessionsWhatsappSession: "Update a session's settings, webhook config or proxy",
   deleteApiWhatsappSessionsWhatsappSession: "Delete a session and revoke its API key",
   postApiWhatsappSessionsWhatsappSessionConnect: "Begin linking, returning a QR code when one is ready",
@@ -68,9 +69,10 @@ const SUMMARIES: Record<string, string> = {
 };
 
 /** Routes whose credential is the account-scoped token rather than a session key. */
-const PAT_ONLY = new Set(
+const PAT_ONLY = new Set<string>(
   ROUTES.filter((r) => r.path.startsWith("/api/whatsapp-sessions")).map((r) => r.operationId),
 );
+PAT_ONLY.add("getApiWhatsappSessionsWhatsappSessionSettings");
 
 const tagFor = (path: string): string => {
   if (path.startsWith("/api/whatsapp-sessions") || path === "/api/status" || path === "/api/user")

--- a/packages/contracts/src/responses.ts
+++ b/packages/contracts/src/responses.ts
@@ -65,6 +65,21 @@ const sessionDetail = sessionSummary.extend({
   webhook_secret: z.string().nullable(),
 });
 
+const sessionSettings = z.object({
+  account_protection: z.boolean(),
+  log_messages: z.boolean(),
+  read_incoming_messages: z.boolean(),
+  auto_reject_calls: z.boolean(),
+  always_online: z.boolean(),
+  ignore_groups: z.boolean(),
+  ignore_channels: z.boolean(),
+  ignore_broadcasts: z.boolean(),
+  proxy_url: z.string().nullable(),
+  webhook_url: z.string().nullable(),
+  webhook_enabled: z.boolean(),
+  webhook_events: z.array(z.string()).nullable(),
+});
+
 /**
  * Contacts come in two shapes, and the difference is theirs, not ours.
  *
@@ -217,6 +232,10 @@ export const SUCCESS_RESPONSES: Record<string, SuccessResponse> = {
   getApiWhatsappSessions: { status: 200, schema: ok(z.array(sessionSummary)) },
   postApiWhatsappSessions: { status: 201, schema: ok(sessionDetail) },
   getApiWhatsappSessionsWhatsappSession: { status: 200, schema: ok(sessionDetail) },
+  getApiWhatsappSessionsWhatsappSessionSettings: {
+    status: 200,
+    schema: ok(sessionSettings),
+  },
   putApiWhatsappSessionsWhatsappSession: { status: 200, schema: ok(sessionDetail) },
   deleteApiWhatsappSessionsWhatsappSession: { status: 204 },
   postApiWhatsappSessionsWhatsappSessionRegenerateKey: {

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -51,6 +51,24 @@ export function sessionDetailToWire(s: WhatsappSession) {
   };
 }
 
+/** Effective persisted settings exposed through the wapi-only settings extension. */
+export function sessionSettingsToWire(s: WhatsappSession) {
+  return {
+    account_protection: s.accountProtection,
+    log_messages: s.logMessages,
+    read_incoming_messages: s.readIncomingMessages,
+    auto_reject_calls: s.autoRejectCalls,
+    always_online: s.alwaysOnline,
+    ignore_groups: s.ignoreGroups,
+    ignore_channels: s.ignoreChannels,
+    ignore_broadcasts: s.ignoreBroadcasts,
+    proxy_url: s.proxyUrl,
+    webhook_url: s.webhookUrl,
+    webhook_enabled: s.webhookEnabled,
+    webhook_events: s.webhookEvents,
+  };
+}
+
 /** A decrypt failure must not 500 the whole request — surface null and log upstream. */
 function safeDecrypt(v: string | null | undefined): string | null {
   if (!v) return null;

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -48,6 +48,7 @@ client.SendPresence(ctx, jid, "composing")            // typing indicator
 client.FetchUsername(ctx, jid)                        // usually null
 
 client.Sessions.List(ctx)                             // PAT
+client.Sessions.Settings(ctx, 3)                      // effective wapi-only controls
 client.Sessions.Connection.Connect(ctx, 3)
 client.Sessions.Keys.Regenerate(ctx, 3)               // old key dies immediately
 client.Sessions.Logs.Messages(ctx, 3, 1)              // what was sent

--- a/sdk/go/sessions.go
+++ b/sdk/go/sessions.go
@@ -47,6 +47,16 @@ func (s *Sessions) Get(ctx context.Context, sessionID int) (*SessionDetail, erro
 	return &out, unwrap(raw, &out)
 }
 
+// Settings returns wapi's effective persisted controls without session credentials.
+func (s *Sessions) Settings(ctx context.Context, sessionID int) (*SessionSettings, error) {
+	raw, err := s.t.do(ctx, "GET", "/api/whatsapp-sessions/"+strconv.Itoa(sessionID)+"/settings", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out SessionSettings
+	return &out, unwrap(raw, &out)
+}
+
 // Create makes a session and issues its API key.
 //
 // Requires at least "name" and "phone_number". The response is the only place the key and webhook

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -39,6 +39,22 @@ type SessionDetail struct {
 	WebhookSecret *string `json:"webhook_secret"`
 }
 
+// SessionSettings are wapi's effective persisted controls, without session credentials.
+type SessionSettings struct {
+	AccountProtection    bool     `json:"account_protection"`
+	LogMessages          bool     `json:"log_messages"`
+	ReadIncomingMessages bool     `json:"read_incoming_messages"`
+	AutoRejectCalls      bool     `json:"auto_reject_calls"`
+	AlwaysOnline         bool     `json:"always_online"`
+	IgnoreGroups         bool     `json:"ignore_groups"`
+	IgnoreChannels       bool     `json:"ignore_channels"`
+	IgnoreBroadcasts     bool     `json:"ignore_broadcasts"`
+	ProxyURL             *string  `json:"proxy_url"`
+	WebhookURL           *string  `json:"webhook_url"`
+	WebhookEnabled       bool     `json:"webhook_enabled"`
+	WebhookEvents        []string `json:"webhook_events"`
+}
+
 // SendResult is what a send returns. MsgID is wapi's own integer sequence, not WhatsApp's id —
 // WhatsApp's is Key.ID on the record returned by Messages.Info.
 type SendResult struct {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -48,6 +48,7 @@ client.send_presence(jid, "composing")           # typing indicator
 client.fetch_username(jid)                       # usually {"username": None}
 
 client.sessions.list()                           # PAT
+client.sessions.settings(3)                      # effective wapi-only controls
 client.sessions.connection.connect(3)
 client.sessions.keys.regenerate(3)               # old key dies immediately
 client.sessions.logs.messages(3, page=1)         # what was sent
@@ -94,9 +95,9 @@ handles its own — which is why a few return a plain `str` rather than a dict.
 **A timeout on a send is ambiguous.** It means the request failed, not that the message went
 undelivered. Retrying blindly sends twice — reconcile with `messages.info(msg_id)`.
 
-**Reactions and the sandbox are wapi extensions.** WasenderAPI reports reactions over webhooks
-but has no endpoint to send one, and has nothing like a sandbox session. Feature-detect if you
-target both.
+**Session settings, reactions and the sandbox are wapi extensions.** WasenderAPI's cloned detail
+shape omits some effective controls, it reports reactions over webhooks but has no endpoint to
+send one, and it has nothing like a sandbox session. Feature-detect if you target both.
 
 **Promote/demote reports differently from add/remove.** `participants.add` and `.remove` return a
 per-participant list of `{status, jid, message}`; `participants.update` returns

--- a/sdk/python/wapi/resources/sessions.py
+++ b/sdk/python/wapi/resources/sessions.py
@@ -119,6 +119,12 @@ class SessionsResource:
         """
         return data(self._http.request("GET", f"/api/whatsapp-sessions/{session_id}"))
 
+    def settings(self, session_id: int) -> Any:
+        """Effective persisted settings exposed by wapi without session credentials."""
+        return data(
+            self._http.request("GET", f"/api/whatsapp-sessions/{session_id}/settings")
+        )
+
     def create(self, **fields: Any) -> Any:
         """Create a session and issue its API key.
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -81,7 +81,7 @@ message was undelivered — retrying sends twice. Reconcile with `messages.info(
 ```
 wapi.status() user() sendPresence() fetchUsername()
 
-wapi.sessions.list() get() create() update() delete()
+wapi.sessions.list() get() settings() create() update() delete()
 wapi.sessions.connection.connect() disconnect() restart() qrCode()
 wapi.sessions.keys.regenerate()
 wapi.sessions.logs.messages() activity()

--- a/sdk/typescript/src/resources/sessions.ts
+++ b/sdk/typescript/src/resources/sessions.ts
@@ -5,6 +5,7 @@ import type {
   GetApiWhatsappSessionsWhatsappSessionQrcodeResponse,
   GetApiWhatsappSessionsWhatsappSessionResponse,
   GetApiWhatsappSessionsWhatsappSessionSessionLogsResponse,
+  GetApiWhatsappSessionsWhatsappSessionSettingsResponse,
   PostApiWhatsappSessionsBody,
   PostApiWhatsappSessionsResponse,
   PostApiWhatsappSessionsWhatsappSessionConnectResponse,
@@ -17,6 +18,8 @@ import type {
 
 export type Session = GetApiWhatsappSessionsResponse["data"][number];
 export type SessionDetail = GetApiWhatsappSessionsWhatsappSessionResponse["data"];
+export type SessionSettings =
+  GetApiWhatsappSessionsWhatsappSessionSettingsResponse["data"];
 
 /**
  * Connecting and disconnecting a session.
@@ -171,6 +174,16 @@ export class SessionsResource {
     );
   }
 
+  /** Effective persisted settings exposed by wapi without session credentials. */
+  async settings(sessionId: number): Promise<SessionSettings> {
+    return data(
+      await this.http.request<GetApiWhatsappSessionsWhatsappSessionSettingsResponse>(
+        "GET",
+        `/api/whatsapp-sessions/${sessionId}/settings`,
+      ),
+    );
+  }
+
   /** Create a session and issue its API key. The key is returned once, here. */
   async create(input: PostApiWhatsappSessionsBody): Promise<SessionDetail> {
     return data(
@@ -207,4 +220,3 @@ export class SessionsResource {
     await this.http.request<void>("DELETE", `/api/whatsapp-sessions/${sessionId}`);
   }
 }
-

--- a/sdk/typescript/src/types.gen.ts
+++ b/sdk/typescript/src/types.gen.ts
@@ -767,6 +767,25 @@ export type PutApiGroupsGroupJidSettingsResponse = {
   };
 };
 
+/** Fetch a session's effective persisted settings. */
+export type GetApiWhatsappSessionsWhatsappSessionSettingsResponse = {
+  success: true;
+  data: {
+    account_protection: boolean;
+    log_messages: boolean;
+    read_incoming_messages: boolean;
+    auto_reject_calls: boolean;
+    always_online: boolean;
+    ignore_groups: boolean;
+    ignore_channels: boolean;
+    ignore_broadcasts: boolean;
+    proxy_url: string | null;
+    webhook_url: string | null;
+    webhook_enabled: boolean;
+    webhook_events: string[] | null;
+  };
+};
+
 /** Request body for `POST /api/messages/react`. */
 export type PostApiMessagesReactBody = {
   key: {
@@ -867,6 +886,7 @@ export type Operations = {
   getApiWhatsappSessionsWhatsappSessionMessageLogs: { method: "GET"; path: "/api/whatsapp-sessions/{whatsappSession}/message-logs"; status: 200 };
   getApiWhatsappSessionsWhatsappSessionQrcode: { method: "GET"; path: "/api/whatsapp-sessions/{whatsappSession}/qrcode"; status: 200 };
   getApiWhatsappSessionsWhatsappSessionSessionLogs: { method: "GET"; path: "/api/whatsapp-sessions/{whatsappSession}/session-logs"; status: 200 };
+  getApiWhatsappSessionsWhatsappSessionSettings: { method: "GET"; path: "/api/whatsapp-sessions/{whatsappSession}/settings"; status: 200 };
   postApiContactsContactPhoneNumberBlock: { method: "POST"; path: "/api/contacts/{contactPhoneNumber}/block"; status: 200 };
   postApiContactsContactPhoneNumberUnblock: { method: "POST"; path: "/api/contacts/{contactPhoneNumber}/unblock"; status: 200 };
   postApiDecryptMedia: { method: "POST"; path: "/api/decrypt-media"; status: 200 };


### PR DESCRIPTION
## Summary
- add a PAT-authenticated WAPI extension for effective persisted session settings
- preserve the cloned Wasender session response shape
- add the extension to OpenAPI and all three SDKs

## Verification
- bun test
- bun run typecheck
- bun ops/check-sdk-in-sync.mjs
- node ops/check-dockerfile-manifests.mjs
- gofmt, go vet, and go build for sdk/go
- apps/web production build
- disposable Postgres/Redis end-to-end sandbox assertion for the authenticated settings route