### PR TITLE
fix(api): limit session settings response

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,8 +363,8 @@ without scanning a QR — by a different route. That would be a wapi extension, 
 an open decision rather than an oversight.
 
 Current extensions: `POST /api/messages/react` (they emit `messages.reaction` as a webhook but
-document no way to send one), `GET /api/whatsapp-sessions/{id}/settings` (effective persisted
-controls omitted by the cloned detail shape), the three `/api/sandbox/*` controls, and
+document no way to send one), `GET /api/whatsapp-sessions/{id}/settings` (the two safety controls
+omitted by the cloned detail shape), the three `/api/sandbox/*` controls, and
 `webhook_hmac`, which is dashboard-only. `/health` reports the cloned count and the extension
 count separately, so the cloned-route claim stays true.
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ That claim is a test suite, not an aspiration: response schemas are checked agai
 provider's own documented examples, and again against live responses.
 
 WAPI-specific capabilities remain separate from that cloned surface. In particular,
-`GET /api/whatsapp-sessions/{id}/settings` exposes effective persisted controls that the cloned
-session-detail response omits, without returning the session credential or webhook secret.
+`GET /api/whatsapp-sessions/{id}/settings` exposes the two effective safety controls that the
+cloned session-detail response omits, without returning any other session configuration.
 
 ## Clients
 

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -86,7 +86,7 @@ export function sessionRoutes(db: Db) {
     return c.json(ok(sessionDetailToWire(row)));
   });
 
-  /** GET /api/whatsapp-sessions/{id}/settings — wapi extension for effective settings. */
+  /** GET /api/whatsapp-sessions/{id}/settings — wapi extension for omitted safety controls. */
   app.get("/whatsapp-sessions/:whatsappSession/settings", async (c) => {
     const row = await findOwned(db, c.get("auth").accountId, c.req.param("whatsappSession"));
     if (!row) return c.json(fail("The specified session was not found."), 404);

--- a/packages/contracts/src/openapi.ts
+++ b/packages/contracts/src/openapi.ts
@@ -35,7 +35,7 @@ const SUMMARIES: Record<string, string> = {
   getApiWhatsappSessions: "List every WhatsApp session on the account",
   postApiWhatsappSessions: "Create a WhatsApp session and issue its API key",
   getApiWhatsappSessionsWhatsappSession: "Fetch one session, including its API key and webhook secret",
-  getApiWhatsappSessionsWhatsappSessionSettings: "Fetch a session's effective persisted settings",
+  getApiWhatsappSessionsWhatsappSessionSettings: "Fetch safety controls omitted by session detail",
   putApiWhatsappSessionsWhatsappSession: "Update a session's settings, webhook config or proxy",
   deleteApiWhatsappSessionsWhatsappSession: "Delete a session and revoke its API key",
   postApiWhatsappSessionsWhatsappSessionConnect: "Begin linking, returning a QR code when one is ready",

--- a/packages/contracts/src/responses.ts
+++ b/packages/contracts/src/responses.ts
@@ -66,18 +66,8 @@ const sessionDetail = sessionSummary.extend({
 });
 
 const sessionSettings = z.object({
-  account_protection: z.boolean(),
-  log_messages: z.boolean(),
   read_incoming_messages: z.boolean(),
-  auto_reject_calls: z.boolean(),
-  always_online: z.boolean(),
   ignore_groups: z.boolean(),
-  ignore_channels: z.boolean(),
-  ignore_broadcasts: z.boolean(),
-  proxy_url: z.string().nullable(),
-  webhook_url: z.string().nullable(),
-  webhook_enabled: z.boolean(),
-  webhook_events: z.array(z.string()).nullable(),
 });
 
 /**

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -51,21 +51,11 @@ export function sessionDetailToWire(s: WhatsappSession) {
   };
 }
 
-/** Effective persisted settings exposed through the wapi-only settings extension. */
+/** Safety controls omitted by the cloned detail shape. */
 export function sessionSettingsToWire(s: WhatsappSession) {
   return {
-    account_protection: s.accountProtection,
-    log_messages: s.logMessages,
     read_incoming_messages: s.readIncomingMessages,
-    auto_reject_calls: s.autoRejectCalls,
-    always_online: s.alwaysOnline,
     ignore_groups: s.ignoreGroups,
-    ignore_channels: s.ignoreChannels,
-    ignore_broadcasts: s.ignoreBroadcasts,
-    proxy_url: s.proxyUrl,
-    webhook_url: s.webhookUrl,
-    webhook_enabled: s.webhookEnabled,
-    webhook_events: s.webhookEvents,
   };
 }
 

--- a/sdk/go/sessions.go
+++ b/sdk/go/sessions.go
@@ -47,7 +47,7 @@ func (s *Sessions) Get(ctx context.Context, sessionID int) (*SessionDetail, erro
 	return &out, unwrap(raw, &out)
 }
 
-// Settings returns wapi's effective persisted controls without session credentials.
+// Settings returns safety controls omitted by the cloned session detail.
 func (s *Sessions) Settings(ctx context.Context, sessionID int) (*SessionSettings, error) {
 	raw, err := s.t.do(ctx, "GET", "/api/whatsapp-sessions/"+strconv.Itoa(sessionID)+"/settings", nil, nil)
 	if err != nil {

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -39,20 +39,10 @@ type SessionDetail struct {
 	WebhookSecret *string `json:"webhook_secret"`
 }
 
-// SessionSettings are wapi's effective persisted controls, without session credentials.
+// SessionSettings are the safety controls omitted by the cloned session detail.
 type SessionSettings struct {
-	AccountProtection    bool     `json:"account_protection"`
-	LogMessages          bool     `json:"log_messages"`
-	ReadIncomingMessages bool     `json:"read_incoming_messages"`
-	AutoRejectCalls      bool     `json:"auto_reject_calls"`
-	AlwaysOnline         bool     `json:"always_online"`
-	IgnoreGroups         bool     `json:"ignore_groups"`
-	IgnoreChannels       bool     `json:"ignore_channels"`
-	IgnoreBroadcasts     bool     `json:"ignore_broadcasts"`
-	ProxyURL             *string  `json:"proxy_url"`
-	WebhookURL           *string  `json:"webhook_url"`
-	WebhookEnabled       bool     `json:"webhook_enabled"`
-	WebhookEvents        []string `json:"webhook_events"`
+	ReadIncomingMessages bool `json:"read_incoming_messages"`
+	IgnoreGroups         bool `json:"ignore_groups"`
 }
 
 // SendResult is what a send returns. MsgID is wapi's own integer sequence, not WhatsApp's id —

--- a/sdk/python/wapi/resources/sessions.py
+++ b/sdk/python/wapi/resources/sessions.py
@@ -120,7 +120,7 @@ class SessionsResource:
         return data(self._http.request("GET", f"/api/whatsapp-sessions/{session_id}"))
 
     def settings(self, session_id: int) -> Any:
-        """Effective persisted settings exposed by wapi without session credentials."""
+        """Safety controls omitted by the cloned session detail."""
         return data(
             self._http.request("GET", f"/api/whatsapp-sessions/{session_id}/settings")
         )

--- a/sdk/typescript/src/resources/sessions.ts
+++ b/sdk/typescript/src/resources/sessions.ts
@@ -174,7 +174,7 @@ export class SessionsResource {
     );
   }
 
-  /** Effective persisted settings exposed by wapi without session credentials. */
+  /** Safety controls omitted by the cloned session detail. */
   async settings(sessionId: number): Promise<SessionSettings> {
     return data(
       await this.http.request<GetApiWhatsappSessionsWhatsappSessionSettingsResponse>(

--- a/sdk/typescript/src/types.gen.ts
+++ b/sdk/typescript/src/types.gen.ts
@@ -767,22 +767,12 @@ export type PutApiGroupsGroupJidSettingsResponse = {
   };
 };
 
-/** Fetch a session's effective persisted settings. */
+/** Fetch safety controls omitted by session detail. */
 export type GetApiWhatsappSessionsWhatsappSessionSettingsResponse = {
   success: true;
   data: {
-    account_protection: boolean;
-    log_messages: boolean;
     read_incoming_messages: boolean;
-    auto_reject_calls: boolean;
-    always_online: boolean;
     ignore_groups: boolean;
-    ignore_channels: boolean;
-    ignore_broadcasts: boolean;
-    proxy_url: string | null;
-    webhook_url: string | null;
-    webhook_enabled: boolean;
-    webhook_events: string[] | null;
   };
 };
 


### PR DESCRIPTION
## Summary
- limit the new WAPI settings extension to the two safety controls omitted by the cloned session detail
- remove unrelated settings, including proxy configuration, from the response contract
- regenerate the TypeScript response type and narrow SDK documentation/types

## Verification
- bun test
- bun run typecheck
- bun ops/check-sdk-in-sync.mjs
- gofmt, go vet, and go build for sdk/go