### PR TITLE
revert: remove session settings extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,10 +363,9 @@ without scanning a QR — by a different route. That would be a wapi extension, 
 an open decision rather than an oversight.
 
 Current extensions: `POST /api/messages/react` (they emit `messages.reaction` as a webhook but
-document no way to send one), `GET /api/whatsapp-sessions/{id}/settings` (the two safety controls
-omitted by the cloned detail shape), the three `/api/sandbox/*` controls, and
-`webhook_hmac`, which is dashboard-only. `/health` reports the cloned count and the extension
-count separately, so the cloned-route claim stays true.
+document no way to send one), the three `/api/sandbox/*` controls, and `webhook_hmac`, which is
+dashboard-only. `/health` reports the cloned count and the extension count separately, so "29
+routes" stays a true claim about fidelity.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,6 @@ would not be.
 That claim is a test suite, not an aspiration: response schemas are checked against the
 provider's own documented examples, and again against live responses.
 
-WAPI-specific capabilities remain separate from that cloned surface. In particular,
-`GET /api/whatsapp-sessions/{id}/settings` exposes the two effective safety controls that the
-cloned session-detail response omits, without returning any other session configuration.
-
 ## Clients
 
 Zero runtime dependencies either side. Types are generated from the OpenAPI document so they

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -7,7 +7,6 @@ import {
   generateWebhookSecret,
   hashToken,
   sessionDetailToWire,
-  sessionSettingsToWire,
   sessionToWire,
   validateProxy,
   validationFailure,
@@ -84,13 +83,6 @@ export function sessionRoutes(db: Db) {
     const row = await findOwned(db, c.get("auth").accountId, c.req.param("whatsappSession"));
     if (!row) return c.json(fail("The specified session was not found."), 404);
     return c.json(ok(sessionDetailToWire(row)));
-  });
-
-  /** GET /api/whatsapp-sessions/{id}/settings — wapi extension for omitted safety controls. */
-  app.get("/whatsapp-sessions/:whatsappSession/settings", async (c) => {
-    const row = await findOwned(db, c.get("auth").accountId, c.req.param("whatsappSession"));
-    if (!row) return c.json(fail("The specified session was not found."), 404);
-    return c.json(ok(sessionSettingsToWire(row)));
   });
 
   /** PUT /api/whatsapp-sessions/{id} — update. This is where proxy_url is set. */
@@ -206,3 +198,4 @@ async function findOwned(db: Db, accountId: number, idParam: string) {
     .limit(1);
   return row ?? null;
 }
+

--- a/compat/sandbox.test.ts
+++ b/compat/sandbox.test.ts
@@ -111,21 +111,6 @@ d("credentials", () => {
   });
 });
 
-d("wapi session settings extension", () => {
-  test("reports the effective safety-critical settings", async () => {
-    const response = await json(
-      await api(`/api/whatsapp-sessions/${sessionId}/settings`, {}, PAT),
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.body["success"]).toBe(true);
-    expect(response.body["data"]).toMatchObject({
-      ignore_groups: false,
-      read_incoming_messages: false,
-    });
-  });
-});
-
 d("the six success envelopes", () => {
   test("GET /api/status is a bare object with no success wrapper", async () => {
     const r = await json(await api("/api/status"));

--- a/packages/contracts/src/extensions.ts
+++ b/packages/contracts/src/extensions.ts
@@ -72,12 +72,6 @@ export const postApiSandboxScanBody = z.object({});
 
 export const EXTENSION_ROUTES = [
   {
-    method: "GET",
-    operationId: "getApiWhatsappSessionsWhatsappSessionSettings",
-    path: "/api/whatsapp-sessions/{whatsappSession}/settings",
-    pathParams: ["whatsappSession"] as string[],
-  },
-  {
     body: postApiMessagesReactBody,
     method: "POST",
     operationId: "postApiMessagesReact",

--- a/packages/contracts/src/openapi.ts
+++ b/packages/contracts/src/openapi.ts
@@ -35,7 +35,6 @@ const SUMMARIES: Record<string, string> = {
   getApiWhatsappSessions: "List every WhatsApp session on the account",
   postApiWhatsappSessions: "Create a WhatsApp session and issue its API key",
   getApiWhatsappSessionsWhatsappSession: "Fetch one session, including its API key and webhook secret",
-  getApiWhatsappSessionsWhatsappSessionSettings: "Fetch safety controls omitted by session detail",
   putApiWhatsappSessionsWhatsappSession: "Update a session's settings, webhook config or proxy",
   deleteApiWhatsappSessionsWhatsappSession: "Delete a session and revoke its API key",
   postApiWhatsappSessionsWhatsappSessionConnect: "Begin linking, returning a QR code when one is ready",
@@ -69,10 +68,9 @@ const SUMMARIES: Record<string, string> = {
 };
 
 /** Routes whose credential is the account-scoped token rather than a session key. */
-const PAT_ONLY = new Set<string>(
+const PAT_ONLY = new Set(
   ROUTES.filter((r) => r.path.startsWith("/api/whatsapp-sessions")).map((r) => r.operationId),
 );
-PAT_ONLY.add("getApiWhatsappSessionsWhatsappSessionSettings");
 
 const tagFor = (path: string): string => {
   if (path.startsWith("/api/whatsapp-sessions") || path === "/api/status" || path === "/api/user")

--- a/packages/contracts/src/responses.ts
+++ b/packages/contracts/src/responses.ts
@@ -65,11 +65,6 @@ const sessionDetail = sessionSummary.extend({
   webhook_secret: z.string().nullable(),
 });
 
-const sessionSettings = z.object({
-  read_incoming_messages: z.boolean(),
-  ignore_groups: z.boolean(),
-});
-
 /**
  * Contacts come in two shapes, and the difference is theirs, not ours.
  *
@@ -222,10 +217,6 @@ export const SUCCESS_RESPONSES: Record<string, SuccessResponse> = {
   getApiWhatsappSessions: { status: 200, schema: ok(z.array(sessionSummary)) },
   postApiWhatsappSessions: { status: 201, schema: ok(sessionDetail) },
   getApiWhatsappSessionsWhatsappSession: { status: 200, schema: ok(sessionDetail) },
-  getApiWhatsappSessionsWhatsappSessionSettings: {
-    status: 200,
-    schema: ok(sessionSettings),
-  },
   putApiWhatsappSessionsWhatsappSession: { status: 200, schema: ok(sessionDetail) },
   deleteApiWhatsappSessionsWhatsappSession: { status: 204 },
   postApiWhatsappSessionsWhatsappSessionRegenerateKey: {

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -51,14 +51,6 @@ export function sessionDetailToWire(s: WhatsappSession) {
   };
 }
 
-/** Safety controls omitted by the cloned detail shape. */
-export function sessionSettingsToWire(s: WhatsappSession) {
-  return {
-    read_incoming_messages: s.readIncomingMessages,
-    ignore_groups: s.ignoreGroups,
-  };
-}
-
 /** A decrypt failure must not 500 the whole request — surface null and log upstream. */
 function safeDecrypt(v: string | null | undefined): string | null {
   if (!v) return null;

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -48,7 +48,6 @@ client.SendPresence(ctx, jid, "composing")            // typing indicator
 client.FetchUsername(ctx, jid)                        // usually null
 
 client.Sessions.List(ctx)                             // PAT
-client.Sessions.Settings(ctx, 3)                      // effective wapi-only controls
 client.Sessions.Connection.Connect(ctx, 3)
 client.Sessions.Keys.Regenerate(ctx, 3)               // old key dies immediately
 client.Sessions.Logs.Messages(ctx, 3, 1)              // what was sent

--- a/sdk/go/sessions.go
+++ b/sdk/go/sessions.go
@@ -47,16 +47,6 @@ func (s *Sessions) Get(ctx context.Context, sessionID int) (*SessionDetail, erro
 	return &out, unwrap(raw, &out)
 }
 
-// Settings returns safety controls omitted by the cloned session detail.
-func (s *Sessions) Settings(ctx context.Context, sessionID int) (*SessionSettings, error) {
-	raw, err := s.t.do(ctx, "GET", "/api/whatsapp-sessions/"+strconv.Itoa(sessionID)+"/settings", nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out SessionSettings
-	return &out, unwrap(raw, &out)
-}
-
 // Create makes a session and issues its API key.
 //
 // Requires at least "name" and "phone_number". The response is the only place the key and webhook

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -39,12 +39,6 @@ type SessionDetail struct {
 	WebhookSecret *string `json:"webhook_secret"`
 }
 
-// SessionSettings are the safety controls omitted by the cloned session detail.
-type SessionSettings struct {
-	ReadIncomingMessages bool `json:"read_incoming_messages"`
-	IgnoreGroups         bool `json:"ignore_groups"`
-}
-
 // SendResult is what a send returns. MsgID is wapi's own integer sequence, not WhatsApp's id —
 // WhatsApp's is Key.ID on the record returned by Messages.Info.
 type SendResult struct {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -48,7 +48,6 @@ client.send_presence(jid, "composing")           # typing indicator
 client.fetch_username(jid)                       # usually {"username": None}
 
 client.sessions.list()                           # PAT
-client.sessions.settings(3)                      # effective wapi-only controls
 client.sessions.connection.connect(3)
 client.sessions.keys.regenerate(3)               # old key dies immediately
 client.sessions.logs.messages(3, page=1)         # what was sent
@@ -95,9 +94,9 @@ handles its own — which is why a few return a plain `str` rather than a dict.
 **A timeout on a send is ambiguous.** It means the request failed, not that the message went
 undelivered. Retrying blindly sends twice — reconcile with `messages.info(msg_id)`.
 
-**Session settings, reactions and the sandbox are wapi extensions.** WasenderAPI's cloned detail
-shape omits some effective controls, it reports reactions over webhooks but has no endpoint to
-send one, and it has nothing like a sandbox session. Feature-detect if you target both.
+**Reactions and the sandbox are wapi extensions.** WasenderAPI reports reactions over webhooks
+but has no endpoint to send one, and has nothing like a sandbox session. Feature-detect if you
+target both.
 
 **Promote/demote reports differently from add/remove.** `participants.add` and `.remove` return a
 per-participant list of `{status, jid, message}`; `participants.update` returns

--- a/sdk/python/wapi/resources/sessions.py
+++ b/sdk/python/wapi/resources/sessions.py
@@ -119,12 +119,6 @@ class SessionsResource:
         """
         return data(self._http.request("GET", f"/api/whatsapp-sessions/{session_id}"))
 
-    def settings(self, session_id: int) -> Any:
-        """Safety controls omitted by the cloned session detail."""
-        return data(
-            self._http.request("GET", f"/api/whatsapp-sessions/{session_id}/settings")
-        )
-
     def create(self, **fields: Any) -> Any:
         """Create a session and issue its API key.
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -81,7 +81,7 @@ message was undelivered — retrying sends twice. Reconcile with `messages.info(
 ```
 wapi.status() user() sendPresence() fetchUsername()
 
-wapi.sessions.list() get() settings() create() update() delete()
+wapi.sessions.list() get() create() update() delete()
 wapi.sessions.connection.connect() disconnect() restart() qrCode()
 wapi.sessions.keys.regenerate()
 wapi.sessions.logs.messages() activity()

--- a/sdk/typescript/src/resources/sessions.ts
+++ b/sdk/typescript/src/resources/sessions.ts
@@ -5,7 +5,6 @@ import type {
   GetApiWhatsappSessionsWhatsappSessionQrcodeResponse,
   GetApiWhatsappSessionsWhatsappSessionResponse,
   GetApiWhatsappSessionsWhatsappSessionSessionLogsResponse,
-  GetApiWhatsappSessionsWhatsappSessionSettingsResponse,
   PostApiWhatsappSessionsBody,
   PostApiWhatsappSessionsResponse,
   PostApiWhatsappSessionsWhatsappSessionConnectResponse,
@@ -18,8 +17,6 @@ import type {
 
 export type Session = GetApiWhatsappSessionsResponse["data"][number];
 export type SessionDetail = GetApiWhatsappSessionsWhatsappSessionResponse["data"];
-export type SessionSettings =
-  GetApiWhatsappSessionsWhatsappSessionSettingsResponse["data"];
 
 /**
  * Connecting and disconnecting a session.
@@ -174,16 +171,6 @@ export class SessionsResource {
     );
   }
 
-  /** Safety controls omitted by the cloned session detail. */
-  async settings(sessionId: number): Promise<SessionSettings> {
-    return data(
-      await this.http.request<GetApiWhatsappSessionsWhatsappSessionSettingsResponse>(
-        "GET",
-        `/api/whatsapp-sessions/${sessionId}/settings`,
-      ),
-    );
-  }
-
   /** Create a session and issue its API key. The key is returned once, here. */
   async create(input: PostApiWhatsappSessionsBody): Promise<SessionDetail> {
     return data(
@@ -220,3 +207,4 @@ export class SessionsResource {
     await this.http.request<void>("DELETE", `/api/whatsapp-sessions/${sessionId}`);
   }
 }
+

--- a/sdk/typescript/src/types.gen.ts
+++ b/sdk/typescript/src/types.gen.ts
@@ -767,15 +767,6 @@ export type PutApiGroupsGroupJidSettingsResponse = {
   };
 };
 
-/** Fetch safety controls omitted by session detail. */
-export type GetApiWhatsappSessionsWhatsappSessionSettingsResponse = {
-  success: true;
-  data: {
-    read_incoming_messages: boolean;
-    ignore_groups: boolean;
-  };
-};
-
 /** Request body for `POST /api/messages/react`. */
 export type PostApiMessagesReactBody = {
   key: {
@@ -876,7 +867,6 @@ export type Operations = {
   getApiWhatsappSessionsWhatsappSessionMessageLogs: { method: "GET"; path: "/api/whatsapp-sessions/{whatsappSession}/message-logs"; status: 200 };
   getApiWhatsappSessionsWhatsappSessionQrcode: { method: "GET"; path: "/api/whatsapp-sessions/{whatsappSession}/qrcode"; status: 200 };
   getApiWhatsappSessionsWhatsappSessionSessionLogs: { method: "GET"; path: "/api/whatsapp-sessions/{whatsappSession}/session-logs"; status: 200 };
-  getApiWhatsappSessionsWhatsappSessionSettings: { method: "GET"; path: "/api/whatsapp-sessions/{whatsappSession}/settings"; status: 200 };
   postApiContactsContactPhoneNumberBlock: { method: "POST"; path: "/api/contacts/{contactPhoneNumber}/block"; status: 200 };
   postApiContactsContactPhoneNumberUnblock: { method: "POST"; path: "/api/contacts/{contactPhoneNumber}/unblock"; status: 200 };
   postApiDecryptMedia: { method: "POST"; path: "/api/decrypt-media"; status: 200 };


### PR DESCRIPTION
Reverts WAPI PRs #1 and #2 in full. This restores the repository tree to pre-change revision e1dc092 because the provisioning fix belongs in Normal, not WAPI.

Verification: the rollback branch tree is byte-for-byte identical to e1dc092.