### PR TITLE
feat(web): polish landing and docs UX

### DIFF
--- a/apps/web/e2e/public.pw.ts
+++ b/apps/web/e2e/public.pw.ts
@@ -77,6 +77,34 @@ test.describe("the landing page", () => {
     await expect(page.locator("body")).toBeVisible();
     expect(errors).toEqual([]);
   });
+
+  test("keeps Docs reachable on a phone without opening the footer", async ({ browser }) => {
+    /**
+     * The centre nav cluster is `hidden md:flex`. Before the mobile row existed, Docs was only
+     * in the footer — selective attention fails when the primary secondary action is below the
+     * fold. Assert the in-nav Docs link is visible at 390px rather than merely present in the DOM.
+     */
+    const page = await browser.newPage({ viewport: { height: 844, width: 390 } });
+    await page.goto("/");
+    const docs = page.locator("nav").getByRole("link", { name: "Docs" });
+    await expect(docs.first()).toBeVisible();
+    await page.close();
+  });
+
+  test("does not scroll sideways on a phone", async ({ browser }) => {
+    /**
+     * The hero terminal's curl is wider than a phone. Without `minmax(0, …)` on the grid and
+     * overflow on the panel, that line sets the page's minimum width and the whole landing
+     * pans horizontally — the same class of bug the docs suite already guards.
+     */
+    const page = await browser.newPage({ viewport: { height: 844, width: 390 } });
+    await page.goto("/");
+    const overflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+    );
+    expect(overflows).toBe(false);
+    await page.close();
+  });
 });
 
 test.describe("the demo video", () => {

--- a/apps/web/src/app/docs/docs.css
+++ b/apps/web/src/app/docs/docs.css
@@ -141,3 +141,23 @@
   font-weight: inherit;
   text-decoration: none;
 }
+
+/*
+ * Index path grouping — proximity without inventing a second palette.
+ *
+ * Extra space before section headings separates "Start here" from "Pick a language" the way a
+ * hairline rule would on the landing page. Tighter sidebar rows keep more of the tree above the
+ * fold (selective attention for the next page).
+ */
+#nd-docs-layout .prose h2 {
+  margin-top: 2.75rem;
+  letter-spacing: -0.03em;
+}
+
+#nd-docs-layout .prose h2:first-of-type {
+  margin-top: 2rem;
+}
+
+#nd-sidebar a {
+  font-size: 0.875rem;
+}

--- a/apps/web/src/app/docs/layout.tsx
+++ b/apps/web/src/app/docs/layout.tsx
@@ -14,11 +14,32 @@ import "./docs.css";
  * `--shiki-dark`. Letting Fumadocs mount a class-based theme switcher would leave the docs and
  * the dashboard disagreeing about what "dark" means the moment somebody used it. Instead the
  * whole site follows the reader's system setting, and `docs.css` maps Fumadocs' tokens onto ours.
+ *
+ * The nav title is the same wordmark as the landing (`wapi.`) and links home — Jakob's law plus
+ * brand continuity so the guide does not feel like a different product from the marketing page.
  */
 export default function DocsRootLayout({ children }: { children: ReactNode }) {
   return (
     <RootProvider search={{ options: { api: "/api/search" } }} theme={{ enabled: false }}>
-      <DocsLayout tree={source.pageTree} nav={{ title: "wapi" }}>
+      <DocsLayout
+        tree={source.pageTree}
+        nav={{
+          title: (
+            <span className="wordmark text-[1.05rem]">
+              wapi<span>.</span>
+            </span>
+          ),
+          url: "/",
+        }}
+        githubUrl="https://github.com/crafter-station/wapi"
+        links={[
+          {
+            text: "API reference",
+            url: "https://api.wapi.crafter.run/docs",
+            external: true,
+          },
+        ]}
+      >
         {children}
       </DocsLayout>
     </RootProvider>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -86,6 +86,7 @@ body {
 
 .shell {
   width: var(--shell);
+  max-width: 100%;
   margin-inline: auto;
 }
 
@@ -182,6 +183,40 @@ body {
   font-size: 0.925rem;
   font-weight: 560;
   transition: opacity 0.15s var(--ease-out), background 0.15s var(--ease-out);
+}
+.btn:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+/*
+ * Keyboard path into the page. Hidden until focused — no visual noise for pointer users,
+ * and the cheapest a11y win that does not need env vars or copy changes.
+ */
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  z-index: 100;
+  border-radius: var(--radius);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 0.875rem;
+  font-weight: 560;
+  padding: 0.65rem 1rem;
+  transform: translateY(-160%);
+  transition: transform 0.15s var(--ease-out);
+}
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }
 .btn-primary {
   background: var(--primary);
@@ -309,6 +344,17 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   overflow: hidden;
+  max-width: 100%;
+}
+/*
+ * Landing hero only. A short border lift on hover gives the panel presence without motion
+ * that would fight prefers-reduced-motion — colour, not transform.
+ */
+.terminal-lift {
+  transition: border-color 0.15s var(--ease-out);
+}
+.terminal-lift:hover {
+  border-color: color-mix(in oklch, var(--foreground) 22%, var(--border));
 }
 .terminal-bar {
   display: flex;
@@ -321,9 +367,18 @@ body {
   letter-spacing: 0.08em;
   color: var(--muted-foreground);
   text-transform: uppercase;
+  min-width: 0;
+}
+.terminal-bar > :last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .terminal-body {
   padding: 1rem 1.15rem;
+  /* Long curl lines scroll inside the panel instead of widening the page (grid min-content). */
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 /* ---------------------------------------------------------------- status */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -50,6 +50,8 @@ export const metadata: Metadata = {
  * page behind it.
  */
 export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
   themeColor: [
     { color: "#0a0a0a", media: "(prefers-color-scheme: light)" },
     { color: "#fafafa", media: "(prefers-color-scheme: dark)" },

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,43 +13,66 @@ import { highlight } from "@/lib/highlight";
  *
  * The content is ours. The hero panel is a terminal because this product's surface is a REST
  * API — showing a curl and its response is the honest equivalent of showing the app.
+ *
+ * Section order is problem → product → how → proof (demo) → honesty → CTA so the reader meets
+ * the gap before the film; the prose in each section is unchanged.
  */
 
 const API = "https://api.wapi.crafter.run";
 
+const NAV_LINK =
+  "inline-flex min-h-11 items-center text-[0.875rem] font-[520] text-[var(--muted-foreground)] transition-colors duration-150 [transition-timing-function:var(--ease-out)] hover:text-[var(--foreground)]";
+
 function Nav() {
   return (
     <nav className="rule">
-      <div className="shell grid grid-cols-[1fr_auto_1fr] items-center gap-6 py-5">
-        <Link href="/" className="wordmark w-fit">
-          wapi<span>.</span>
-        </Link>
-        <div className="hidden items-center gap-8 text-[0.875rem] font-[520] md:flex">
-          <a href="#how" className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
+      <div className="shell py-4 md:py-5">
+        <div className="grid grid-cols-[1fr_auto] items-center gap-4 md:grid-cols-[1fr_auto_1fr] md:gap-6">
+          <Link href="/" className="wordmark w-fit">
+            wapi<span>.</span>
+          </Link>
+          <div className="hidden items-center gap-8 md:flex">
+            <a href="#how" className={NAV_LINK}>
+              How it works
+            </a>
+            <Link href="/docs" className={NAV_LINK}>
+              Docs
+            </Link>
+            <a href={`${API}/docs`} className={NAV_LINK}>
+              API reference
+            </a>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <GithubLink />
+            <SignedIn>
+              <Link href="/sessions" className="btn btn-primary min-h-11">
+                Dashboard
+              </Link>
+            </SignedIn>
+            <SignedOut>
+              <SignInButton mode="modal">
+                <button type="button" className="btn btn-primary min-h-11">
+                  Get started
+                </button>
+              </SignInButton>
+            </SignedOut>
+          </div>
+        </div>
+        {/*
+         * Mobile-only destinations. Desktop already has the centre cluster; hiding those links
+         * entirely on small screens forced Docs into the footer. Three destinations + the primary
+         * CTA above is enough — do not add a hamburger.
+         */}
+        <div className="mt-3 flex gap-1 overflow-x-auto scroll-slim md:hidden">
+          <a href="#how" className={`${NAV_LINK} px-2`}>
             How it works
           </a>
-          <Link href="/docs" className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
+          <Link href="/docs" className={`${NAV_LINK} px-2`}>
             Docs
           </Link>
-          <a
-            href={`${API}/docs`}
-            className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-          >
+          <a href={`${API}/docs`} className={`${NAV_LINK} px-2`}>
             API reference
           </a>
-        </div>
-        <div className="flex items-center justify-end gap-2">
-          <GithubLink />
-          <SignedIn>
-            <Link href="/sessions" className="btn btn-primary">
-              Dashboard
-            </Link>
-          </SignedIn>
-          <SignedOut>
-            <SignInButton mode="modal">
-              <button className="btn btn-primary">Get started</button>
-            </SignInButton>
-          </SignedOut>
         </div>
       </div>
     </nav>
@@ -78,7 +101,7 @@ async function HeroTerminal() {
   );
 
   return (
-    <div className="terminal w-full max-w-[560px]">
+    <div className="terminal terminal-lift w-full max-w-[560px] min-w-0">
       <div className="terminal-bar">
         <span className="status status-connected">connected</span>
         <span className="ml-auto">POST /api/send-message</span>
@@ -95,12 +118,16 @@ async function HeroTerminal() {
 export default async function Home() {
   return (
     <>
+      <a href="#main" className="skip-link">
+        Skip to content
+      </a>
       <Nav />
 
+      <main id="main">
       {/* ------------------------------------------------------------------ hero */}
       <section className="hero-wash rule">
-        <div className="shell grid items-center gap-14 py-20 lg:grid-cols-[1.05fr_1fr] lg:py-28">
-          <div>
+        <div className="shell grid min-w-0 items-center gap-10 py-14 sm:gap-14 sm:py-20 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)] lg:py-28">
+          <div className="min-w-0">
             <p className="kicker">Self-hosted WhatsApp API</p>
             <h1 className="display mt-6">
               WhatsApp over HTTP, <em>on your own box.</em>
@@ -112,16 +139,18 @@ export default async function Home() {
             </p>
             <div className="mt-9 flex flex-wrap items-center gap-4">
               <SignedIn>
-                <Link href="/sessions" className="btn btn-primary">
+                <Link href="/sessions" className="btn btn-primary min-h-11">
                   Open dashboard
                 </Link>
               </SignedIn>
               <SignedOut>
                 <SignInButton mode="modal">
-                  <button className="btn btn-primary">Link a number</button>
+                  <button type="button" className="btn btn-primary min-h-11">
+                    Link a number
+                  </button>
                 </SignInButton>
               </SignedOut>
-              <Link href="/docs" className="btn btn-ghost">
+              <Link href="/docs" className="btn btn-ghost min-h-11">
                 Read the guide
               </Link>
             </div>
@@ -129,39 +158,15 @@ export default async function Home() {
               Sessions live on your server. Credentials never leave your database.
             </p>
           </div>
-          <div className="justify-self-center lg:justify-self-end">
+          <div className="min-w-0 w-full justify-self-center lg:justify-self-end">
             <HeroTerminal />
           </div>
         </div>
       </section>
 
-      {/* ---------------------------------------------------------------- demo */}
-      <section className="rule">
-        <div className="shell grid items-center gap-12 py-20 lg:grid-cols-[1fr_1.15fr]">
-          <div>
-            <p className="kicker">Watch it</p>
-            <h2 className="title mt-5">
-              Your WhatsApp, <em>over HTTP.</em>
-            </h2>
-            <p className="lede mt-6">
-              Seventy-eight seconds on a live account: messages, images, stickers, video and
-              documents landing in a real thread with WhatsApp&rsquo;s own delivery ticks, then a
-              group — and finally a sandbox, where a contact who does not exist fires a genuine
-              webhook.
-            </p>
-            <p className="mt-5 text-[0.85rem] text-[var(--muted-foreground)]">
-              Every command in it was recorded from the real CLI against a real session, and the
-              number is masked at capture time — see{" "}
-              <code className="code">ops/capture-demo.mjs</code>.
-            </p>
-          </div>
-          <DemoVideo />
-        </div>
-      </section>
-
       {/* -------------------------------------------------------------- tension */}
       <section className="rule">
-        <div className="shell grid gap-10 py-20 lg:grid-cols-[1.1fr_1fr]">
+        <div className="shell grid min-w-0 gap-10 py-20 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
           <div>
             <p className="kicker">The gap</p>
             <h2 className="title mt-5">
@@ -251,9 +256,33 @@ export default async function Home() {
         </div>
       </section>
 
+      {/* ---------------------------------------------------------------- demo */}
+      <section className="rule">
+        <div className="shell grid min-w-0 items-center gap-12 py-20 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
+          <div>
+            <p className="kicker">Watch it</p>
+            <h2 className="title mt-5">
+              Your WhatsApp, <em>over HTTP.</em>
+            </h2>
+            <p className="lede mt-6">
+              Seventy-eight seconds on a live account: messages, images, stickers, video and
+              documents landing in a real thread with WhatsApp&rsquo;s own delivery ticks, then a
+              group — and finally a sandbox, where a contact who does not exist fires a genuine
+              webhook.
+            </p>
+            <p className="mt-5 text-[0.85rem] text-[var(--muted-foreground)]">
+              Every command in it was recorded from the real CLI against a real session, and the
+              number is masked at capture time — see{" "}
+              <code className="code">ops/capture-demo.mjs</code>.
+            </p>
+          </div>
+          <DemoVideo />
+        </div>
+      </section>
+
       {/* ------------------------------------------------------------ honesty */}
       <section className="rule">
-        <div className="shell grid gap-10 py-20 lg:grid-cols-[1fr_1.1fr]">
+        <div className="shell grid min-w-0 gap-10 py-20 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
           <div>
             <p className="kicker">Worth knowing</p>
             <h2 className="title mt-5">
@@ -281,40 +310,49 @@ export default async function Home() {
           <h2 className="title mx-auto max-w-[720px]">
             Link a number and <em>send your first message.</em>
           </h2>
-          <div className="mt-9 flex justify-center gap-4">
+          <div className="mt-9 flex flex-wrap justify-center gap-4">
             <SignedIn>
-              <Link href="/sessions" className="btn btn-primary">
+              <Link href="/sessions" className="btn btn-primary min-h-11">
                 Open dashboard
               </Link>
             </SignedIn>
             <SignedOut>
               <SignInButton mode="modal">
-                <button className="btn btn-primary">Get started</button>
+                <button type="button" className="btn btn-primary min-h-11">
+                  Get started
+                </button>
               </SignInButton>
             </SignedOut>
-            <Link href="/docs" className="btn btn-ghost">
+            <Link href="/docs" className="btn btn-ghost min-h-11">
               Documentation
             </Link>
           </div>
         </div>
       </section>
+      </main>
 
       <footer className="rule border-t">
         <div className="shell flex flex-wrap items-center justify-between gap-4 py-8 text-[0.85rem] text-[var(--muted-foreground)]">
           <span className="wordmark text-[1rem]">
             wapi<span>.</span>
           </span>
-          <div className="flex gap-6">
-            <Link href="/docs" className="hover:text-[var(--foreground)]">
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+            <Link href="/docs" className="inline-flex min-h-11 items-center hover:text-[var(--foreground)]">
               Docs
             </Link>
-            <a href={`${API}/docs`} className="hover:text-[var(--foreground)]">
+            <a
+              href={`${API}/docs`}
+              className="inline-flex min-h-11 items-center hover:text-[var(--foreground)]"
+            >
               API reference
             </a>
-            <a href={`${API}/openapi.json`} className="hover:text-[var(--foreground)]">
+            <a
+              href={`${API}/openapi.json`}
+              className="inline-flex min-h-11 items-center hover:text-[var(--foreground)]"
+            >
               OpenAPI
             </a>
-            <GithubLink className="!p-0" />
+            <GithubLink className="!p-0 min-h-11 min-w-11" />
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- Landing: mobile Docs/How nav, section order (problem → product → how → demo), skip link / focus, hero overflow contained on narrow viewports — owner copy unchanged
- Docs: `wapi.` wordmark home link, API reference + GitHub in the shell, light typography/sidebar rhythm
- E2E: Docs reachable at 390px; landing must not scroll sideways

## Test plan
- [ ] `bun run --cwd apps/web typecheck`
- [ ] Manually open `/` at ~390px: no horizontal pan; Docs visible in nav
- [ ] Tab to reveal Skip to content, activate, lands in `#main`
- [ ] Open `/docs`: wordmark returns to `/`; API reference link works
- [ ] `bun run --cwd apps/web e2e -- e2e/public.pw.ts` (needs `apps/web/.env.local` / Clerk)