### PR TITLE
feat(web): landing hero copy and nav follow-ups

### DIFF
--- a/apps/web/e2e/public.pw.ts
+++ b/apps/web/e2e/public.pw.ts
@@ -80,15 +80,29 @@ test.describe("the landing page", () => {
 
   test("keeps Docs reachable on a phone without opening the footer", async ({ browser }) => {
     /**
-     * The centre nav cluster is `hidden md:flex`. Before the mobile row existed, Docs was only
-     * in the footer — selective attention fails when the primary secondary action is below the
-     * fold. Assert the in-nav Docs link is visible at 390px rather than merely present in the DOM.
+     * The landing nav keeps Docs in the single mobile row (scrollable centre), not only in the
+     * footer. Assert it stays visible at 390px.
      */
     const page = await browser.newPage({ viewport: { height: 844, width: 390 } });
     await page.goto("/");
     const docs = page.locator("nav").getByRole("link", { name: "Docs" });
     await expect(docs.first()).toBeVisible();
     await page.close();
+  });
+
+  test("keeps centre nav links after returning from docs", async ({ page }) => {
+    /**
+     * Soft-nav from Fumadocs back to `/` used to leave the centre cluster on `display: none`
+     * when Tailwind's `hidden md:flex` lost to leftover docs utilities. Assert at desktop width
+     * that How / Docs / API are still there after the round trip.
+     */
+    await page.setViewportSize({ width: 1100, height: 800 });
+    await page.goto("/docs");
+    await page.goto("/");
+    const nav = page.locator("nav");
+    await expect(nav.getByRole("link", { name: "How it works" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "Docs" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "API reference" })).toBeVisible();
   });
 
   test("does not scroll sideways on a phone", async ({ browser }) => {
@@ -104,6 +118,17 @@ test.describe("the landing page", () => {
     );
     expect(overflows).toBe(false);
     await page.close();
+  });
+
+  test("copies the hero curl from the terminal bar", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.goto("/");
+    const copy = page.locator(".terminal").getByRole("button", { name: /copy/i });
+    await expect(copy).toBeVisible();
+    await copy.click();
+    await expect
+      .poll(async () => (await page.evaluate(() => navigator.clipboard.readText())).trim())
+      .toMatch(/^curl -X POST/);
   });
 });
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -90,6 +90,82 @@ body {
   margin-inline: auto;
 }
 
+/*
+ * Landing nav — own breakpoints, not Tailwind `hidden`/`md:flex`.
+ *
+ * Soft-navigating home from `/docs` can leave Fumadocs utility CSS in the cascade. A centre
+ * cluster that starts as `hidden` and only becomes `md:flex` then stays invisible on a wide
+ * viewport while the mobile row stays `md:hidden` — exactly the empty-nav screenshot. These
+ * rules always display the links; only their grid placement changes.
+ *
+ * Mobile stays one row: brand | scrollable links | actions. A second wrapped row under the
+ * CTA reads as a broken header, not as navigation.
+ */
+.landing-nav {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 0.75rem;
+  padding-block: 0.85rem;
+}
+.landing-nav-brand {
+  justify-self: start;
+}
+.landing-nav-links {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 0.15rem;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.landing-nav-links::-webkit-scrollbar {
+  height: 0;
+}
+.landing-nav-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  justify-self: end;
+}
+.landing-nav-link {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  min-height: 2.75rem;
+  padding-inline: 0.45rem;
+  font-size: 0.8125rem;
+  font-weight: 520;
+  color: var(--muted-foreground);
+  transition: color 0.15s var(--ease-out);
+}
+.landing-nav-link:hover {
+  color: var(--foreground);
+}
+
+@media (min-width: 768px) {
+  .landing-nav {
+    grid-template-columns: 1fr auto 1fr;
+    column-gap: 1.5rem;
+    padding-block: 1.25rem;
+  }
+  .landing-nav-links {
+    justify-content: center;
+    gap: 2rem;
+    overflow: visible;
+  }
+  .landing-nav-link {
+    padding-inline: 0;
+    font-size: 0.875rem;
+  }
+  .landing-nav-actions {
+    gap: 0.5rem;
+  }
+}
+
+
 /* ---------------------------------------------------------------- typography */
 
 .display {
@@ -360,7 +436,7 @@ button:focus-visible {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.6rem 0.9rem;
+  padding: 0.45rem 0.65rem 0.45rem 0.9rem;
   border-bottom: 1px solid var(--border);
   font-family: var(--font-mono);
   font-size: 0.7rem;
@@ -369,10 +445,19 @@ button:focus-visible {
   text-transform: uppercase;
   min-width: 0;
 }
-.terminal-bar > :last-child {
+.terminal-bar-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.terminal-bar-copy {
+  margin-inline-start: auto;
+  flex-shrink: 0;
+  min-height: 2.75rem;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 0.75rem;
 }
 .terminal-body {
   padding: 1rem 1.15rem;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { SignedIn, SignedOut, SignInButton } from "@clerk/nextjs";
 import { GithubLink } from "@/components/github-link";
 import { DemoVideo } from "@/components/demo-video";
+import { CopyButton } from "@/components/copy-button";
 import { highlight } from "@/lib/highlight";
 
 /**
@@ -13,66 +14,59 @@ import { highlight } from "@/lib/highlight";
  *
  * The content is ours. The hero panel is a terminal because this product's surface is a REST
  * API — showing a curl and its response is the honest equivalent of showing the app.
- *
- * Section order is problem → product → how → proof (demo) → honesty → CTA so the reader meets
- * the gap before the film; the prose in each section is unchanged.
  */
 
 const API = "https://api.wapi.crafter.run";
 
-const NAV_LINK =
-  "inline-flex min-h-11 items-center text-[0.875rem] font-[520] text-[var(--muted-foreground)] transition-colors duration-150 [transition-timing-function:var(--ease-out)] hover:text-[var(--foreground)]";
+/**
+ * Landing nav links.
+ *
+ * Kept as one list (not a `hidden md:flex` cluster plus a `md:hidden` row). Soft-navigating
+ * back from `/docs` leaves Fumadocs' Tailwind layers in the document; those can win over
+ * utility breakpoints and leave the centre links on `display: none` while the mobile row
+ * stays hidden — an empty nav on a wide viewport. Plain CSS in `globals.css` owns the
+ * breakpoints for this chrome so that fight cannot happen.
+ */
+function NavLinks() {
+  return (
+    <>
+      <a href="#how" className="landing-nav-link">
+        How it works
+      </a>
+      <Link href="/docs" className="landing-nav-link">
+        Docs
+      </Link>
+      <a href={`${API}/docs`} className="landing-nav-link">
+        API reference
+      </a>
+    </>
+  );
+}
 
 function Nav() {
   return (
     <nav className="rule">
-      <div className="shell py-4 md:py-5">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-4 md:grid-cols-[1fr_auto_1fr] md:gap-6">
-          <Link href="/" className="wordmark w-fit">
-            wapi<span>.</span>
-          </Link>
-          <div className="hidden items-center gap-8 md:flex">
-            <a href="#how" className={NAV_LINK}>
-              How it works
-            </a>
-            <Link href="/docs" className={NAV_LINK}>
-              Docs
-            </Link>
-            <a href={`${API}/docs`} className={NAV_LINK}>
-              API reference
-            </a>
-          </div>
-          <div className="flex items-center justify-end gap-2">
-            <GithubLink />
-            <SignedIn>
-              <Link href="/sessions" className="btn btn-primary min-h-11">
-                Dashboard
-              </Link>
-            </SignedIn>
-            <SignedOut>
-              <SignInButton mode="modal">
-                <button type="button" className="btn btn-primary min-h-11">
-                  Get started
-                </button>
-              </SignInButton>
-            </SignedOut>
-          </div>
+      <div className="shell landing-nav">
+        <Link href="/" className="wordmark landing-nav-brand">
+          wapi<span>.</span>
+        </Link>
+        <div className="landing-nav-links">
+          <NavLinks />
         </div>
-        {/*
-         * Mobile-only destinations. Desktop already has the centre cluster; hiding those links
-         * entirely on small screens forced Docs into the footer. Three destinations + the primary
-         * CTA above is enough — do not add a hamburger.
-         */}
-        <div className="mt-3 flex gap-1 overflow-x-auto scroll-slim md:hidden">
-          <a href="#how" className={`${NAV_LINK} px-2`}>
-            How it works
-          </a>
-          <Link href="/docs" className={`${NAV_LINK} px-2`}>
-            Docs
-          </Link>
-          <a href={`${API}/docs`} className={`${NAV_LINK} px-2`}>
-            API reference
-          </a>
+        <div className="landing-nav-actions">
+          <GithubLink />
+          <SignedIn>
+            <Link href="/sessions" className="btn btn-primary min-h-11">
+              Dashboard
+            </Link>
+          </SignedIn>
+          <SignedOut>
+            <SignInButton mode="modal">
+              <button type="button" className="btn btn-primary min-h-11">
+                Get started
+              </button>
+            </SignInButton>
+          </SignedOut>
         </div>
       </div>
     </nav>
@@ -86,14 +80,15 @@ function Nav() {
  * the honest equivalent of showing the app is showing a request and its response. Highlighted
  * with the same build-time highlighter as the documentation, so the colours a reader sees here
  * are the colours they see in the guide.
+ *
+ * The copy control pastes the curl only — that is what a reader would run — matching every
+ * other code chrome on the site (`CodeBlock` / `CodeTabs`).
  */
 async function HeroTerminal() {
-  const request = await highlight(
-    `curl -X POST ${API}/api/send-message \
+  const curl = `curl -X POST ${API}/api/send-message \
   -H "Authorization: Bearer $KEY" \
-  -d '{"to":"+51999888777","text":"hello"}'`,
-    "bash",
-  );
+  -d '{"to":"+51999888777","text":"hello"}'`;
+  const request = await highlight(curl, "bash");
   const response = await highlight(
     `{ "success": true,
   "data": { "msgId": 100024, "status": "in_progress" } }`,
@@ -104,7 +99,8 @@ async function HeroTerminal() {
     <div className="terminal terminal-lift w-full max-w-[560px] min-w-0">
       <div className="terminal-bar">
         <span className="status status-connected">connected</span>
-        <span className="ml-auto">POST /api/send-message</span>
+        <span className="terminal-bar-label">POST /api/send-message</span>
+        <CopyButton text={curl} className="terminal-bar-copy" />
       </div>
       <div className="terminal-body code">
         <div dangerouslySetInnerHTML={{ __html: request }} />
@@ -161,6 +157,30 @@ export default async function Home() {
           <div className="min-w-0 w-full justify-self-center lg:justify-self-end">
             <HeroTerminal />
           </div>
+        </div>
+      </section>
+
+      {/* ---------------------------------------------------------------- demo */}
+      <section className="rule">
+        <div className="shell grid min-w-0 items-center gap-12 py-20 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
+          <div>
+            <p className="kicker">Watch it</p>
+            <h2 className="title mt-5">
+              Your WhatsApp, <em>over HTTP.</em>
+            </h2>
+            <p className="lede mt-6">
+              Seventy-eight seconds on a live account: messages, images, stickers, video and
+              documents landing in a real thread with WhatsApp&rsquo;s own delivery ticks, then a
+              group — and finally a sandbox, where a contact who does not exist fires a genuine
+              webhook.
+            </p>
+            <p className="mt-5 text-[0.85rem] text-[var(--muted-foreground)]">
+              Every command in it was recorded from the real CLI against a real session, and the
+              number is masked at capture time — see{" "}
+              <code className="code">ops/capture-demo.mjs</code>.
+            </p>
+          </div>
+          <DemoVideo />
         </div>
       </section>
 
@@ -253,30 +273,6 @@ export default async function Home() {
               </li>
             ))}
           </ol>
-        </div>
-      </section>
-
-      {/* ---------------------------------------------------------------- demo */}
-      <section className="rule">
-        <div className="shell grid min-w-0 items-center gap-12 py-20 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
-          <div>
-            <p className="kicker">Watch it</p>
-            <h2 className="title mt-5">
-              Your WhatsApp, <em>over HTTP.</em>
-            </h2>
-            <p className="lede mt-6">
-              Seventy-eight seconds on a live account: messages, images, stickers, video and
-              documents landing in a real thread with WhatsApp&rsquo;s own delivery ticks, then a
-              group — and finally a sandbox, where a contact who does not exist fires a genuine
-              webhook.
-            </p>
-            <p className="mt-5 text-[0.85rem] text-[var(--muted-foreground)]">
-              Every command in it was recorded from the real CLI against a real session, and the
-              number is masked at capture time — see{" "}
-              <code className="code">ops/capture-demo.mjs</code>.
-            </p>
-          </div>
-          <DemoVideo />
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Add a `CopyButton` on the landing hero terminal that copies the curl (same control as docs code blocks)
- Keep nav links in a single scrollable row (no two-row mobile header) using plain CSS so soft-nav from docs cannot blank the centre links
- Restore Watch it immediately after the hero; contain terminal overflow on narrow viewports
- Extend public e2e: nav after docs round-trip, no sideways scroll, clipboard copies the curl

## Test plan
- [ ] `bun run --cwd apps/web typecheck`
- [ ] `/` hero terminal: Copy → paste starts with `curl -X POST`
- [ ] Phone width (~390px): one-row nav; Docs visible; no horizontal page scroll
- [ ] Desktop: Docs → back to `/` — How / Docs / API still visible in the nav
- [ ] Section order: Hero → Watch it → The gap → …
- [ ] `bun run --cwd apps/web e2e -- e2e/public.pw.ts` (needs Clerk `.env.local`)